### PR TITLE
fix: remove redundant styles

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -14,8 +14,6 @@
 
 body {
   margin: 0;
-  place-items: center;
-  justify-content: center;
   min-width: 320px;
   min-height: 100vh;
 }


### PR DESCRIPTION
These styles has no effect on the project, but hides the top portion of the component when it overflows.

https://github.com/wixplosives/codux/assets/87900560/0e9680a9-3569-442b-9805-f927370b99f9
